### PR TITLE
Change notification email to alias to prevent spam

### DIFF
--- a/index.d/projects.yaml
+++ b/index.d/projects.yaml
@@ -7,7 +7,7 @@ Projects:
     git-path: wget/
     target-file: Dockerfile
     desired-tag: latest
-    notify-email: shahdharmit@gmail.com
+    notify-email: container-status-report@centos.org
     depends-on: centos/centos:latest
 
   - id: 2
@@ -18,7 +18,7 @@ Projects:
     git-path: demo
     target-file: Dockerfile.demo
     desired-tag: release
-    notify-email: shahdharmit@gmail.com
+    notify-email: container-status-report@centos.org
     depends-on: centos/centos:latest
 
   - id: 3
@@ -29,7 +29,7 @@ Projects:
     git-path: /
     target-file: Dockerfile.centos
     desired-tag: latest
-    notify-email: shahdharmit@gmail.com
+    notify-email: container-status-report@centos.org
     build-context: ./
     depends-on: centos/centos:latest
 
@@ -41,7 +41,7 @@ Projects:
     git-path: /
     target-file: Dockerfile.centos
     desired-tag: latest
-    notify-email: shahdharmit@gmail.com
+    notify-email: container-status-report@centos.org
     build-context: ./
     depends-on: centos/centos:latest
 
@@ -53,7 +53,7 @@ Projects:
     git-path: /
     target-file: Dockerfile
     desired-tag: 92394f2
-    notify-email: shahdharmit@gmail.com
+    notify-email: container-status-report@centos.org
     build-context: ./
     depends-on: centos/centos:7
 
@@ -65,7 +65,7 @@ Projects:
     git-path: /
     target-file: Dockerfile
     desired-tag: latest
-    notify-email: shahdharmit@gmail.com
+    notify-email: container-status-report@centos.org
     build-context: ./
     depends-on: centos/centos:7
 
@@ -76,7 +76,7 @@ Projects:
     git-path: images/base
     git-branch: release-3.9
     target-file: Dockerfile
-    notify-email: shahdharmit@gmail.com
+    notify-email: container-status-report@centos.org
     desired-tag: latest
     build-context: ./
     depends-on: openshift/origin-source:latest
@@ -88,7 +88,7 @@ Projects:
     git-path: images/source
     git-branch: 3.9_origin-source_cccp_yaml
     target-file: Dockerfile.pipeline
-    notify-email: shahdharmit@gmail.com
+    notify-email: container-status-report@centos.org
     desired-tag: latest
     build-context: ./
     depends-on: centos/centos:latest
@@ -101,7 +101,7 @@ Projects:
     git-path: docker
     target-file: Dockerfile
     desired-tag: latest
-    notify-email: shahdharmit@gmail.com
+    notify-email: container-status-report@centos.org
     build-context: ./
     depends-on: null
 


### PR DESCRIPTION
At the moment, team members' clusters are spamming my inbox. 